### PR TITLE
Fix: item color misalignment issue

### DIFF
--- a/MediainfoProjectNg/Converter/ChapterLanguageToColorConverter.cs
+++ b/MediainfoProjectNg/Converter/ChapterLanguageToColorConverter.cs
@@ -24,7 +24,7 @@ namespace MediainfoProjectNg.Converter
 
             bool hasLanguageIssues = chapterLanguages.Count > 1 || (chapterLanguages.Count == 1 && chapterLanguages[0] == "");
 
-            return hasLanguageIssues ? Brushes.Yellow : Binding.DoNothing;
+            return hasLanguageIssues ? Brushes.Yellow : DependencyProperty.UnsetValue;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/MediainfoProjectNg/Converter/ColorSpaceToColorConverter.cs
+++ b/MediainfoProjectNg/Converter/ColorSpaceToColorConverter.cs
@@ -16,7 +16,7 @@ namespace MediainfoProjectNg.Converter
             switch (info.ColorSpace)
             {
                 case "YUV420":
-                    return Binding.DoNothing;
+                    return DependencyProperty.UnsetValue;
                 default:
                     return Brushes.Orange;
             }

--- a/MediainfoProjectNg/Converter/FpsToTextColorConverter.cs
+++ b/MediainfoProjectNg/Converter/FpsToTextColorConverter.cs
@@ -17,7 +17,7 @@ namespace MediainfoProjectNg.Converter
             switch (info.Fps)
             {
                 case "23.976 (24000/1001)":
-                    return Binding.DoNothing;
+                    return DependencyProperty.UnsetValue;
                 case "29.970 (30000/1001)":
                 case "59.940 (60000/1001)":
                     return Brushes.Olive;


### PR DESCRIPTION
This pull request updates several value converters in the `MediainfoProjectNg/Converter` directory to improve how they signal "no value" conditions to the UI. Instead of returning `Binding.DoNothing`, the converters now return `DependencyProperty.UnsetValue`, which is the recommended approach in WPF for indicating that a binding should not set a value.

Improvements to value converter behavior:

* [`ChapterLanguageToColorConverter.cs`](diffhunk://#diff-f2585db30bf41f481f8a935e36b9f991f888aa81c0771e8f7a45e1ad9aaf2ab5L27-R27): Changed the return value from `Binding.DoNothing` to `DependencyProperty.UnsetValue` when there are language issues.
* [`ColorSpaceToColorConverter.cs`](diffhunk://#diff-ff4822a451c584453cc89deeba740f1300b1a99547b5974eef914192ca579870L19-R19): Updated the converter to return `DependencyProperty.UnsetValue` instead of `Binding.DoNothing` for the "YUV420" color space case.
* [`FpsToTextColorConverter.cs`](diffhunk://#diff-628f36b3be9997ac1834427d86580012c65b57fda571325435a58b1cefdc33daL20-R20): Modified the converter to return `DependencyProperty.UnsetValue` instead of `Binding.DoNothing` for the "23.976 (24000/1001)" FPS case.